### PR TITLE
Increase reputation with single user tagging

### DIFF
--- a/src/bots/Reputation.test.ts
+++ b/src/bots/Reputation.test.ts
@@ -328,6 +328,46 @@ describe('ReputationBot', () => {
         },
       });
     });
+
+    // TODO Testing when user is mention, but the username is changed after
+    // user was added to db
+    it.skip('when user mentions another user with "thank you"', async () => {
+      // Scriber adds user (omar_alfaruq) after he joins
+      await createUserInDb();
+      const mainMessage = createTgTextMessage('Is it your new PC?', {
+        chat: thisChat,
+        from: recipientUser,
+        reply_to_message: undefined,
+      });
+      // lets say omar_alfaruq changes username to omar_new
+      const triggerMessage = createTgTextMessage('@omar_new thank you', {
+        chat: thisChat,
+        from: senderUser,
+        entities: [
+          {
+            type: 'mention',
+            offset: 0,
+            length: 13,
+          },
+        ],
+      });
+
+      const messages = await runBot([ScriberBot, ReputationBot], ({ sendMessage }) => {
+        sendMessage(mainMessage);
+        sendMessage(triggerMessage);
+      });
+
+      assertBotSaid(messages, /increased reputation/);
+      await assert({
+        ...triggerMessage,
+        reply_to_message: {
+          from: {
+            id: 2,
+            username: 'omar_new',
+          },
+        },
+      });
+    });
   });
 
   describe('decreases reputation', () => {

--- a/src/bots/Reputation.test.ts
+++ b/src/bots/Reputation.test.ts
@@ -806,7 +806,7 @@ describe('ReputationBot', () => {
         sendMessage(triggerMessage);
       });
 
-      assertBotSaid(messages, /.*?/);
+      assertBotSaid(messages, 'Tag only one user at a time to increase rep!');
       await assert(0);
     });
   });

--- a/src/bots/Reputation.ts
+++ b/src/bots/Reputation.ts
@@ -1,6 +1,7 @@
 import { Composer } from 'telegraf';
 import { EntityManager } from 'typeorm';
 import { Reputation, voteQuota, voteQuotaDuration, defaultVoteValue } from '../entity/Reputation';
+import { User } from '../entity/User';
 import {
   Chat as TelegramChat,
   User as TelegramUser,
@@ -10,41 +11,78 @@ import { MsocietyBotContext } from '../context';
 
 const bot = new Composer<MsocietyBotContext>();
 
-bot.hears(/thank you|thanks|👍|💯|👆|🆙|🔥/i, async ctx => {
-  if (ctx.message.reply_to_message !== undefined) {
-    const sender = ctx.message.from;
-    const recipient = ctx.message.reply_to_message.from;
-    const canVote = await Reputation.isAllowedToVote(ctx.entityManager, sender);
+async function vote(ctx: MsocietyBotContext, sender: TelegramUser, recipient: TelegramUser) {
+  const canVote = await Reputation.isAllowedToVote(ctx.entityManager, sender);
 
-    // Can't vote for yourself :)
-    if (recipient.id === sender.id) {
-      await ctx.reply('Good try there but nope. 🙃', { reply_to_message_id: ctx.message.message_id });
-    }
-    // Can't vote for the bot.
-    else if (recipient.id === ctx.botInfo.id) {
-      // eslint-disable-next-line quotes
-      await ctx.reply("🙂 I'm flattered but there's no point in licking my boots.", {
+  // Can't vote for yourself :)
+  if (recipient.id === sender.id) {
+    await ctx.reply('Good try there but nope. 🙃', { reply_to_message_id: ctx.message.message_id });
+  }
+
+  // Can't vote for the bot.
+  else if (recipient.id === ctx.botInfo.id) {
+    // eslint-disable-next-line quotes
+    await ctx.reply("🙂 I'm flattered but there's no point in licking my boots.", {
+      reply_to_message_id: ctx.message.message_id,
+    });
+  }
+
+  // Does user have enough votes in their quota to give out?
+  else if (!canVote) {
+    const { nextVote } = await Reputation.getVoteQuota(ctx.entityManager, ctx.message.from);
+
+    await ctx.replyWithMarkdown(
+      `You have already used up your vote quota of ${voteQuota} for the past ${voteQuotaDuration} hours. Please try again later!\nYou will receive a new vote in *${nextVote.hours} hours* and *${nextVote.minutes} minutes*`,
+      { reply_to_message_id: ctx.message.message_id },
+    );
+  }
+
+  // Can't vote for bots
+  else if (!recipient.is_bot && canVote) {
+    await insertReputation(ctx.entityManager, sender, recipient, ctx.chat, ctx.message, defaultVoteValue);
+    const senderRep = await Reputation.getLocalReputation(ctx.entityManager, sender, ctx.chat);
+    const recipientRep = await Reputation.getLocalReputation(ctx.entityManager, recipient, ctx.chat);
+    await ctx.replyWithMarkdown(
+      `*${sender.first_name}* (${senderRep}) has increased reputation of *${recipient.first_name}* (${recipientRep})`,
+      { reply_to_message_id: ctx.message.message_id },
+    );
+  }
+}
+
+bot.hears(/thank you|thanks|👍|💯|👆|🆙|🔥/i, async ctx => {
+  const mentionEntities =
+    ctx.message?.entities?.filter(entity => ['mention', 'text_mention'].includes(entity.type)) || [];
+  if (ctx.message.reply_to_message !== undefined) {
+    await vote(ctx, ctx.from, ctx.message.reply_to_message.from);
+  } else if (
+    // check if there is a mention
+    mentionEntities.length
+  ) {
+    if (mentionEntities.length > 1) {
+      await ctx.reply('Tag only one user at a time to increase rep!', {
         reply_to_message_id: ctx.message.message_id,
       });
+      return;
     }
-    // Does user have enough votes in their quota to give out?
-    else if (!canVote) {
-      const { nextVote } = await Reputation.getVoteQuota(ctx.entityManager, ctx.message.from);
+    // get the mention metadata
+    const entity = mentionEntities[0];
 
-      await ctx.replyWithMarkdown(
-        `You have already used up your vote quota of ${voteQuota} for the past ${voteQuotaDuration} hours. Please try again later!\nYou will receive a new vote in *${nextVote.hours} hours* and *${nextVote.minutes} minutes*`,
-        { reply_to_message_id: ctx.message.message_id },
-      );
-    }
-    // Can't vote for bots
-    else if (!recipient.is_bot && canVote) {
-      await insertReputation(ctx.entityManager, sender, recipient, ctx.chat, ctx.message, defaultVoteValue);
-      const senderRep = await Reputation.getLocalReputation(ctx.entityManager, sender, ctx.chat);
-      const recipientRep = await Reputation.getLocalReputation(ctx.entityManager, recipient, ctx.chat);
-      await ctx.replyWithMarkdown(
-        `*${sender.first_name}* (${senderRep}) has increased reputation of *${recipient.first_name}* (${recipientRep})`,
-        { reply_to_message_id: ctx.message.message_id },
-      );
+    if (entity.type === 'mention') {
+      //get username from text using metadata
+      const username = ctx.message.text.substr(entity.offset + 1, entity.length - 1);
+      // telegram api doesn't provide resolving user by username so we depend on our db to get userID
+      const recipientId = (await User.getUserByUsername(ctx.entityManager, username))?.id;
+      if (!recipientId) {
+        // eslint-disable-next-line quotes
+        await ctx.reply("Can't find user in DB. Did they change their username?", {
+          reply_to_message_id: ctx.message.message_id,
+        });
+        return;
+      }
+      const recipient = await ctx.getChatMember(+recipientId);
+      await vote(ctx, ctx.message.from, recipient.user);
+    } else if (entity.type === 'text_mention') {
+      await vote(ctx, ctx.message.from, entity.user);
     }
   }
 });

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -1,4 +1,14 @@
-import { Entity, Column, BeforeInsert, BeforeUpdate, ManyToMany, JoinTable, OneToMany, PrimaryColumn } from 'typeorm';
+import {
+  Entity,
+  Column,
+  BeforeInsert,
+  BeforeUpdate,
+  ManyToMany,
+  JoinTable,
+  OneToMany,
+  PrimaryColumn,
+  EntityManager,
+} from 'typeorm';
 import { Role } from './Role';
 import { UserPreference } from './UserPreference';
 import { Chat } from './Chat';
@@ -90,4 +100,12 @@ export class User {
   onBeforeUpdateHook(): void {
     this.updatedAt = new Date();
   }
+
+  static getUserByUsername = async (entityManager: EntityManager, username: string): Promise<User> => {
+    return await entityManager.findOne(User, {
+      where: {
+        username: username,
+      },
+    });
+  };
 }

--- a/src/testUtils/TelegramMock.ts
+++ b/src/testUtils/TelegramMock.ts
@@ -2,7 +2,7 @@
 import nock, { ReplyFnResult } from 'nock';
 import { NockResponse } from '../types/testOnly';
 import { isRegExp } from 'util';
-import { Chat, CommonMessageBundle, Message, Update, User } from 'telegraf/typings/core/types/typegram';
+import { Chat, ChatMember, CommonMessageBundle, Message, Update, User } from 'telegraf/typings/core/types/typegram';
 
 type Predicate = (uri: string, requestBody: Record<string, any>) => boolean;
 interface ResponseGenerator {
@@ -27,6 +27,17 @@ const USER_USER: User = {
   id: 1,
   is_bot: false,
   first_name: 'User',
+};
+
+const CHATUSER_USER: ChatMember = {
+  status: 'member',
+  user: {
+    id: 2,
+    first_name: 'Omar',
+    last_name: 'Al-Faruq',
+    username: 'omar_alfaruq',
+    is_bot: false,
+  },
 };
 
 const CHAT: Chat.GroupChat = {
@@ -143,6 +154,14 @@ function setupNock(
     .reply(200, {
       ok: true,
       result: BOT_USER,
+    })
+    .persist();
+
+  nock(apiRoot)
+    .post(/\/bot(.+?)\/getChatMember/)
+    .reply(200, {
+      ok: true,
+      result: CHATUSER_USER,
     })
     .persist();
 


### PR DESCRIPTION
Closes #71 
--

- Update `bot.hears(/thank you|thanks|👍|💯|👆|🆙|🔥/i` logic with checking of mentions
- For entity type `mentions` we get the username and query db for the User data
- For entity type `text_mentions` User is provided
- When multiple users are mentioned, bot responds with message and reputation not increased
- Added test case and mock

### Edge Case

Feature wont work if user changes their username.