### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         file: coverage/coverage-final.json
         fail_ci_if_error: false
     - name: Publish to Docker Hub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       if: ${{ github.ref == 'refs/heads/master' }}
       with:
         name: msociety/msocietybot


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore